### PR TITLE
Set `required_pull_request_reviews: nil`

### DIFF
--- a/github/lib/configure_github_repo.rb
+++ b/github/lib/configure_github_repo.rb
@@ -49,6 +49,8 @@ class ConfigureGitHubRepo
           },
           allow_force_pushes: opts[:allow_force_push_to_master],
           required_linear_history: opts[:require_linear_history],
+          required_pull_request_reviews: nil,
+          accept: Octokit::Preview::PREVIEW_TYPES[:branch_protection],
         )
       elsif branch_protection?
         client.unprotect_branch(


### PR DESCRIPTION
This is a required parameter, even when I don't want to change the
value.

Also set the `accept`, to remove a warning about this endpoint.