### PR TITLE
Compare branch protection rules without order

### DIFF
--- a/github/lib/configure_github_repo.rb
+++ b/github/lib/configure_github_repo.rb
@@ -30,7 +30,7 @@ class ConfigureGitHubRepo
 
     check_attr :master_branch_protection, branch_protection?
     if opts[:master_branch_protection]
-      check_attr :required_status_checks, branch_protection.dig(:required_status_checks, :contexts)
+      check_attr :required_status_checks, branch_protection.dig(:required_status_checks, :contexts).sort
       check_attr :enforce_admins, branch_protection.dig(:enforce_admins, :enabled)
       check_attr :up_to_date_branches, branch_protection.dig(:required_status_checks, :strict)
       check_attr :require_linear_history, branch_protection.dig(:required_linear_history, :enabled)
@@ -76,7 +76,7 @@ private
       master_branch_protection: branch_rules.fetch("master_branch_protection", required_status_checks?),
       enforce_admins: branch_rules.fetch("enforce_admins", true),
       up_to_date_branches: branch_rules.fetch("up_to_date_branches", false),
-      required_status_checks: branch_rules.fetch("required_status_checks", required_status_checks),
+      required_status_checks: branch_rules.fetch("required_status_checks", required_status_checks).sort,
       allow_force_push_to_master: branch_rules.fetch("allow_force_push_to_master", false),
       require_linear_history: branch_rules.fetch("require_linear_history", false),
     }


### PR DESCRIPTION
If the checks are the same, modulo order, then the change will be a
no-op.  But showing a difference in the output suggests that there
will be a change, and so is confusing.