### PR TITLE
Enable YAML linting, fix lint errors, and add a test step for Octodns

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,3 +37,10 @@ jobs:
         run: |
           cd concourse/feed-resource
           pip install -r requirements-freeze.txt
+      - name: Check Configuration (octodns)
+        run: |
+          cd dns
+          pip install octodns boto3
+          export AWS_ACCESS_KEY_ID=dummy
+          export AWS_SECRET_ACCESS_KEY=dummy
+          octodns-validate --config-file dns.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Run tests
 
-on: pull_request
+"on": pull_request
 
 jobs:
   lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,11 @@ jobs:
           cd github
           bundle
           bundle exec rubocop
+      - name: Lint (yaml)
+        run: |
+          set -ex
+          pip install yamllint
+          yamllint -s .
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,5 @@
+extends: default
+
+rules:
+  document-start: disable
+  line-length: disable

--- a/dns/dns.yaml
+++ b/dns/dns.yaml
@@ -7,7 +7,7 @@ providers:
     class: octodns.provider.yaml.YamlProvider
     directory: ./zones
     default_ttl: 300
-    enforce_order: True
+    enforce_order: true
   route53:
     class: octodns.provider.route53.Route53Provider
     access_key_id: env/AWS_ACCESS_KEY_ID

--- a/dns/zones/archhurd.org.yaml
+++ b/dns/zones/archhurd.org.yaml
@@ -1,20 +1,20 @@
 ---
 "":
-- type: "A"
-  values:
-  - "128.199.32.197"
-- type: "MX"
-  values:
-  - exchange: "."
-    preference: 0
-- type: "TXT"
-  values:
-  - "v=spf1 -all"
+  - type: "A"
+    values:
+      - "128.199.32.197"
+  - type: "MX"
+    values:
+      - exchange: "."
+        preference: 0
+  - type: "TXT"
+    values:
+      - "v=spf1 -all"
 
 "*":
-- type: "A"
-  values:
-  - "128.199.32.197"
+  - type: "A"
+    values:
+      - "128.199.32.197"
 
 "*._domainkey":
   type: "TXT"
@@ -23,4 +23,4 @@
 "_dmarc":
   type: "TXT"
   values:
-  - "v=DMARC1\\; p=reject\\; sp=reject\\; adkim=s\\; aspf=s\\; fo=1\\; rua=mailto:mike+dmarc@barrucadu.co.uk"
+    - "v=DMARC1\\; p=reject\\; sp=reject\\; adkim=s\\; aspf=s\\; fo=1\\; rua=mailto:mike+dmarc@barrucadu.co.uk"

--- a/dns/zones/barrucadu.co.uk.yaml
+++ b/dns/zones/barrucadu.co.uk.yaml
@@ -1,34 +1,34 @@
 ---
 "":
-- type: "A"
-  values:
-  - "116.203.134.200"
-- type: "AAAA"
-  values:
-  - "2a01:4f8:c2c:2b22::"
-- type: "MX"
-  values:
-  - exchange: "mail.protonmail.ch."
-    preference: 10
-  - exchange: "mailsec.protonmail.ch."
-    preference: 20
-- type: "TXT"
-  values:
-  - "protonmail-verification=68e94ed315f5df9a3060beb99c6c8ca059e0c741"
-  - "v=spf1 include:_spf.protonmail.ch mx ~all"
+  - type: "A"
+    values:
+      - "116.203.134.200"
+  - type: "AAAA"
+    values:
+      - "2a01:4f8:c2c:2b22::"
+  - type: "MX"
+    values:
+      - exchange: "mail.protonmail.ch."
+        preference: 10
+      - exchange: "mailsec.protonmail.ch."
+        preference: 20
+  - type: "TXT"
+    values:
+      - "protonmail-verification=68e94ed315f5df9a3060beb99c6c8ca059e0c741"
+      - "v=spf1 include:_spf.protonmail.ch mx ~all"
 
 "*":
-- type: "A"
-  values:
-  - "116.203.134.200"
-- type: "AAAA"
-  values:
-  - "2a01:4f8:c2c:2b22::"
+  - type: "A"
+    values:
+      - "116.203.134.200"
+  - type: "AAAA"
+    values:
+      - "2a01:4f8:c2c:2b22::"
 
 "_dmarc":
   type: "TXT"
   values:
-  - "v=DMARC1\\; p=none\\; rua=mailto:mike+dmarc@barrucadu.co.uk"
+    - "v=DMARC1\\; p=none\\; rua=mailto:mike+dmarc@barrucadu.co.uk"
 
 "dreamlands":
   type: "CNAME"

--- a/dns/zones/barrucadu.com.yaml
+++ b/dns/zones/barrucadu.com.yaml
@@ -1,26 +1,26 @@
 ---
 "":
-- type: "A"
-  values:
-  - "116.203.134.200"
-- type: "AAAA"
-  values:
-  - "2a01:4f8:c2c:2b22::"
-- type: "MX"
-  values:
-  - exchange: "."
-    preference: 0
-- type: "TXT"
-  values:
-  - "v=spf1 -all"
+  - type: "A"
+    values:
+      - "116.203.134.200"
+  - type: "AAAA"
+    values:
+      - "2a01:4f8:c2c:2b22::"
+  - type: "MX"
+    values:
+      - exchange: "."
+        preference: 0
+  - type: "TXT"
+    values:
+      - "v=spf1 -all"
 
 "*":
-- type: "A"
-  values:
-  - "116.203.134.200"
-- type: "AAAA"
-  values:
-  - "2a01:4f8:c2c:2b22::"
+  - type: "A"
+    values:
+      - "116.203.134.200"
+  - type: "AAAA"
+    values:
+      - "2a01:4f8:c2c:2b22::"
 
 "*._domainkey":
   type: "TXT"
@@ -29,4 +29,4 @@
 "_dmarc":
   type: "TXT"
   values:
-  - "v=DMARC1\\; p=reject\\; sp=reject\\; adkim=s\\; aspf=s\\; fo=1\\; rua=mailto:mike+dmarc@barrucadu.co.uk"
+    - "v=DMARC1\\; p=reject\\; sp=reject\\; adkim=s\\; aspf=s\\; fo=1\\; rua=mailto:mike+dmarc@barrucadu.co.uk"

--- a/dns/zones/barrucadu.dev.yaml
+++ b/dns/zones/barrucadu.dev.yaml
@@ -1,26 +1,26 @@
 ---
 "":
-- type: "A"
-  values:
-  - "94.130.74.147"
-- type: "AAAA"
-  values:
-  - "2a01:4f8:c0c:77b3::"
-- type: "MX"
-  values:
-  - exchange: "."
-    preference: 0
-- type: "TXT"
-  values:
-  - "v=spf1 -all"
+  - type: "A"
+    values:
+      - "94.130.74.147"
+  - type: "AAAA"
+    values:
+      - "2a01:4f8:c0c:77b3::"
+  - type: "MX"
+    values:
+      - exchange: "."
+        preference: 0
+  - type: "TXT"
+    values:
+      - "v=spf1 -all"
 
 "*":
-- type: "A"
-  values:
-  - "94.130.74.147"
-- type: "AAAA"
-  values:
-  - "2a01:4f8:c0c:77b3::"
+  - type: "A"
+    values:
+      - "94.130.74.147"
+  - type: "AAAA"
+    values:
+      - "2a01:4f8:c0c:77b3::"
 
 "*._domainkey":
   type: "TXT"
@@ -29,4 +29,4 @@
 "_dmarc":
   type: "TXT"
   values:
-  - "v=DMARC1\\; p=reject\\; sp=reject\\; adkim=s\\; aspf=s\\; fo=1\\; rua=mailto:mike+dmarc@barrucadu.co.uk"
+    - "v=DMARC1\\; p=reject\\; sp=reject\\; adkim=s\\; aspf=s\\; fo=1\\; rua=mailto:mike+dmarc@barrucadu.co.uk"

--- a/dns/zones/barrucadu.uk.yaml
+++ b/dns/zones/barrucadu.uk.yaml
@@ -1,26 +1,26 @@
 ---
 "":
-- type: "A"
-  values:
-  - "116.203.134.200"
-- type: "AAAA"
-  values:
-  - "2a01:4f8:c2c:2b22::"
-- type: "MX"
-  values:
-  - exchange: "."
-    preference: 0
-- type: "TXT"
-  values:
-  - "v=spf1 -all"
+  - type: "A"
+    values:
+      - "116.203.134.200"
+  - type: "AAAA"
+    values:
+      - "2a01:4f8:c2c:2b22::"
+  - type: "MX"
+    values:
+      - exchange: "."
+        preference: 0
+  - type: "TXT"
+    values:
+      - "v=spf1 -all"
 
 "*":
-- type: "A"
-  values:
-  - "116.203.134.200"
-- type: "AAAA"
-  values:
-  - "2a01:4f8:c2c:2b22::"
+  - type: "A"
+    values:
+      - "116.203.134.200"
+  - type: "AAAA"
+    values:
+      - "2a01:4f8:c2c:2b22::"
 
 "*._domainkey":
   type: "TXT"
@@ -29,4 +29,4 @@
 "_dmarc":
   type: "TXT"
   values:
-  - "v=DMARC1\\; p=reject\\; sp=reject\\; adkim=s\\; aspf=s\\; fo=1\\; rua=mailto:mike+dmarc@barrucadu.co.uk"
+    - "v=DMARC1\\; p=reject\\; sp=reject\\; adkim=s\\; aspf=s\\; fo=1\\; rua=mailto:mike+dmarc@barrucadu.co.uk"

--- a/dns/zones/lainon.life.yaml
+++ b/dns/zones/lainon.life.yaml
@@ -1,26 +1,26 @@
 ---
 "":
-- type: "A"
-  values:
-  - "91.121.0.148"
-- type: "AAAA"
-  values:
-  - "2001:41d0:0001:5394::1"
-- type: "MX"
-  values:
-  - exchange: "."
-    preference: 0
-- type: "TXT"
-  values:
-  - "v=spf1 -all"
+  - type: "A"
+    values:
+      - "91.121.0.148"
+  - type: "AAAA"
+    values:
+      - "2001:41d0:0001:5394::1"
+  - type: "MX"
+    values:
+      - exchange: "."
+        preference: 0
+  - type: "TXT"
+    values:
+      - "v=spf1 -all"
 
 "*":
-- type: "A"
-  values:
-  - "91.121.0.148"
-- type: "AAAA"
-  values:
-  - "2001:41d0:0001:5394::1"
+  - type: "A"
+    values:
+      - "91.121.0.148"
+  - type: "AAAA"
+    values:
+      - "2001:41d0:0001:5394::1"
 
 "*._domainkey":
   type: "TXT"
@@ -29,4 +29,4 @@
 "_dmarc":
   type: "TXT"
   values:
-  - "v=DMARC1\\; p=reject\\; sp=reject\\; adkim=s\\; aspf=s\\; fo=1\\; rua=mailto:mike+dmarc@barrucadu.co.uk"
+    - "v=DMARC1\\; p=reject\\; sp=reject\\; adkim=s\\; aspf=s\\; fo=1\\; rua=mailto:mike+dmarc@barrucadu.co.uk"

--- a/dns/zones/lookwhattheshoggothdraggedin.com.yaml
+++ b/dns/zones/lookwhattheshoggothdraggedin.com.yaml
@@ -1,26 +1,26 @@
 ---
 "":
-- type: "A"
-  values:
-  - "116.203.134.200"
-- type: "AAAA"
-  values:
-  - "2a01:4f8:c2c:2b22::"
-- type: "MX"
-  values:
-  - exchange: "."
-    preference: 0
-- type: "TXT"
-  values:
-  - "v=spf1 -all"
+  - type: "A"
+    values:
+      - "116.203.134.200"
+  - type: "AAAA"
+    values:
+      - "2a01:4f8:c2c:2b22::"
+  - type: "MX"
+    values:
+      - exchange: "."
+        preference: 0
+  - type: "TXT"
+    values:
+      - "v=spf1 -all"
 
 "*":
-- type: "A"
-  values:
-  - "116.203.134.200"
-- type: "AAAA"
-  values:
-  - "2a01:4f8:c2c:2b22::"
+  - type: "A"
+    values:
+      - "116.203.134.200"
+  - type: "AAAA"
+    values:
+      - "2a01:4f8:c2c:2b22::"
 
 "*._domainkey":
   type: "TXT"
@@ -29,4 +29,4 @@
 "_dmarc":
   type: "TXT"
   values:
-  - "v=DMARC1\\; p=reject\\; sp=reject\\; adkim=s\\; aspf=s\\; fo=1\\; rua=mailto:mike+dmarc@barrucadu.co.uk"
+    - "v=DMARC1\\; p=reject\\; sp=reject\\; adkim=s\\; aspf=s\\; fo=1\\; rua=mailto:mike+dmarc@barrucadu.co.uk"

--- a/dns/zones/uzbl.org.yaml
+++ b/dns/zones/uzbl.org.yaml
@@ -1,26 +1,26 @@
 ---
 "":
-- type: "A"
-  values:
-  - "116.203.134.200"
-- type: "AAAA"
-  values:
-  - "2a01:4f8:c2c:2b22::"
-- type: "MX"
-  values:
-  - exchange: "."
-    preference: 0
-- type: "TXT"
-  values:
-  - "v=spf1 -all"
+  - type: "A"
+    values:
+      - "116.203.134.200"
+  - type: "AAAA"
+    values:
+      - "2a01:4f8:c2c:2b22::"
+  - type: "MX"
+    values:
+      - exchange: "."
+        preference: 0
+  - type: "TXT"
+    values:
+      - "v=spf1 -all"
 
 "*":
-- type: "A"
-  values:
-  - "116.203.134.200"
-- type: "AAAA"
-  values:
-  - "2a01:4f8:c2c:2b22::"
+  - type: "A"
+    values:
+      - "116.203.134.200"
+  - type: "AAAA"
+    values:
+      - "2a01:4f8:c2c:2b22::"
 
 "*._domainkey":
   type: "TXT"
@@ -29,4 +29,4 @@
 "_dmarc":
   type: "TXT"
   values:
-  - "v=DMARC1\\; p=reject\\; sp=reject\\; adkim=s\\; aspf=s\\; fo=1\\; rua=mailto:mike+dmarc@barrucadu.co.uk"
+    - "v=DMARC1\\; p=reject\\; sp=reject\\; adkim=s\\; aspf=s\\; fo=1\\; rua=mailto:mike+dmarc@barrucadu.co.uk"


### PR DESCRIPTION
I've disabled the line-length (because sometimes a line just can't be broken easily, eg if it's a string literal) and document-start checks (because I mostly don't use those).

While doing this I realised that I've got a mix of files called `.yml` and files called `.yaml`.  I don't think this can be fully resolved, due to some tools looking for files with only one extension.