### PR TITLE
Set up carcosa.barrucadu.co.uk

### DIFF
--- a/aws/concourse.tf
+++ b/aws/concourse.tf
@@ -16,7 +16,7 @@ resource "aws_kms_key" "concourse" {
 /* ************************************************************************* */
 
 locals {
-  concourse_ip_addresses = ["94.130.74.147/32", "2a01:4f8:c0c:77b3::/64"]
+  concourse_ip_addresses = ["94.130.74.147/32", "2a01:4f8:c0c:77b3::/64", "116.203.34.201/32", "2a01:4f8:c0c:bfc1::/64"]
 }
 
 resource "aws_iam_policy" "concourse" {

--- a/dns/zones/barrucadu.co.uk.yaml
+++ b/dns/zones/barrucadu.co.uk.yaml
@@ -25,10 +25,22 @@
     values:
       - "2a01:4f8:c2c:2b22::"
 
+"*.carcosa":
+  type: "CNAME"
+  value: "carcosa.barrucadu.co.uk."
+
 "_dmarc":
   type: "TXT"
   values:
     - "v=DMARC1\\; p=none\\; rua=mailto:mike+dmarc@barrucadu.co.uk"
+
+"carcosa":
+  - type: "A"
+    values:
+      - "116.203.34.201"
+  - type: "AAAA"
+    values:
+      - "2a01:4f8:c0c:bfc1::"
 
 "dreamlands":
   type: "CNAME"


### PR DESCRIPTION
This is a new, larger, VPS which I'm going to use to replace dreamlands, dunwich, and part of lainon.life.  Like the others, hosted with Hetzner Cloud.