### PR TITLE
Delete dreamlands.barrucadu.co.uk

### DIFF
--- a/dns/zones/barrucadu.co.uk.yaml
+++ b/dns/zones/barrucadu.co.uk.yaml
@@ -38,14 +38,6 @@
   type: "CNAME"
   value: "barrucadu.co.uk."
 
-"dreamlands":
-  - type: "A"
-    values:
-      - "94.130.74.147"
-  - type: "AAAA"
-    values:
-      - "2a01:4f8:c0c:77b3::"
-
 "dunwich":
   - type: "A"
     values:

--- a/dns/zones/barrucadu.dev.yaml
+++ b/dns/zones/barrucadu.dev.yaml
@@ -26,7 +26,3 @@
   type: "TXT"
   values:
     - "v=DMARC1\\; p=reject\\; sp=reject\\; adkim=s\\; aspf=s\\; fo=1\\; rua=mailto:mike+dmarc@barrucadu.co.uk"
-
-"git":
-  type: "CNAME"
-  value: "dreamlands.barrucadu.co.uk."


### PR DESCRIPTION
dreamlands is now fully migrated, and the server can be deleted.