### PR TITLE
Skip branch protection for fonts repo

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -21,3 +21,7 @@ barrucadu/lookwhattheshoggothdraggedin.com:
 barrucadu/memo.barrucadu.co.uk:
   branch_protection:
     master_branch_protection: false
+
+barrucadu/fonts:
+  branch_protection:
+    master_branch_protection: false


### PR DESCRIPTION
This is a private repo, so branch protection is unavailable unless I
pay.