### PR TITLE
Ignore 403 on GET branch protection

### DIFF
--- a/github/lib/configure_github_repo.rb
+++ b/github/lib/configure_github_repo.rb
@@ -120,5 +120,7 @@ private
       repo[:default_branch],
       accept: Octokit::Preview::PREVIEW_TYPES[:branch_protection],
     ).to_h
+  rescue Octokit::Forbidden
+    {}
   end
 end


### PR DESCRIPTION
This will happen if the repository is private.  In such cases, we can
just treat it as having no branch protection rules: unless the config
overrides it, this will then make the script try to set up branch
protection, which will raise an error which doesn't get ignored.