### PR TITLE
Change DMARC policy for barrucadu.co.uk to "reject"

### DIFF
--- a/dns/zones/barrucadu.co.uk.yaml
+++ b/dns/zones/barrucadu.co.uk.yaml
@@ -28,7 +28,7 @@
 "_dmarc":
   type: "TXT"
   values:
-    - "v=DMARC1\\; p=none\\; rua=mailto:mike+dmarc@barrucadu.co.uk"
+    - "v=DMARC1\\; p=reject\\; rua=mailto:mike+dmarc@barrucadu.co.uk"
 
 "carcosa":
   type: "CNAME"


### PR DESCRIPTION
"none" was useful when first setting up DMARC, as I could check the
reports to make sure nothing was going wrong.  But this record has
been in place since mid-2019, I can send email just fine, and I get
occasional DMARC reports; so it's time to change it to "reject".