### PR TITLE
Block public access to the backups bucket

### DIFF
--- a/aws/backups.tf
+++ b/aws/backups.tf
@@ -33,6 +33,15 @@ resource "aws_s3_bucket" "backups" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "backups" {
+  bucket = aws_s3_bucket.backups.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 /* ************************************************************************* */
 
 resource "aws_iam_policy" "backups" {


### PR DESCRIPTION
The objects inside the bucket are private, and even if they were
disclosed they're encrypted client-side, but an additional layer of
defence is nice to have.