### PR TITLE
Allow backups user to publish to SNS topic

### DIFF
--- a/aws/notifications.tf
+++ b/aws/notifications.tf
@@ -2,6 +2,11 @@ resource "aws_iam_user" "notifications" {
   name = "notifications"
 }
 
+resource "aws_iam_user_policy_attachment" "backups" {
+  user       = aws_iam_user.backups.name
+  policy_arn = aws_iam_policy.notifications.arn
+}
+
 resource "aws_iam_user_policy_attachment" "notifications" {
   user       = aws_iam_user.notifications.name
   policy_arn = aws_iam_policy.notifications.arn


### PR DESCRIPTION
Right now my backups script needs credentials for both the backups and
notifications IAM users, which is due to how it used to work: backups
had its own secrets, and would call a notifications script which had
separate secrets.  But now that the backups script is calling AWS
directly, this separation is inconvenient.