### PR TITLE
Revert "Use my fork of pleroma"

### DIFF
--- a/concourse/pipelines/pleroma.yml
+++ b/concourse/pipelines/pleroma.yml
@@ -23,7 +23,7 @@ resources:
   - name: pleroma-git
     type: git
     source:
-      uri: https://github.com/barrucadu/pleroma.git
+      uri: https://git.pleroma.social/pleroma/pleroma.git
   - name: pleroma-image
     type: docker-image
     source:


### PR DESCRIPTION
The upstream Dockerfile has been fixed, so there's no need to use my fork any more.

This reverts commit f740cf8b88808004836c39396b843b175441d5a9.