### PR TITLE
[dns] Point lainon.life to carcosa

### DIFF
--- a/dns/zones/lainon.life.yaml
+++ b/dns/zones/lainon.life.yaml
@@ -2,10 +2,10 @@
 "":
   - type: "A"
     values:
-      - "91.121.0.148"
+      - "116.203.34.201"
   - type: "AAAA"
     values:
-      - "2001:41d0:0001:5394::1"
+      - "2a01:4f8:c0c:bfc1::"
   - type: "MX"
     values:
       - exchange: "."


### PR DESCRIPTION
The lainon.life server has died (hard drive failure), so I'm moving services to carcosa.