### PR TITLE
[github] Adjust dejafu required status checks

### DIFF
--- a/github/repo_overrides.yml
+++ b/github/repo_overrides.yml
@@ -7,14 +7,14 @@ barrucadu/dejafu:
     required_status_checks:
       - "doctest"
       - "lint"
-      - "test (lts-9.0)"
       - "test (lts-10.0)"
       - "test (lts-12.0)"
-      - "test (lts-13.3)"
+      - "test (lts-14.0)"
       - "test (lts-15.0)"
       - "test (lts-17.0)"
       - "test (lts-19.0)"
       - "test (lts-20.0)"
+      - "test (nightly-2023-01-01)"
 
 barrucadu/lookwhattheshoggothdraggedin.com:
   branch_protection:


### PR DESCRIPTION
https://github.com/barrucadu/dejafu/pull/395

- removes `lts-9.0`
- replaces `lts-13.3` with `lts-14.0`

https://github.com/barrucadu/dejafu/pull/394

- adds `nightly-2023-01-01`