### PR TITLE
Set SNS SMS sender ID

### DIFF
--- a/aws/notifications.tf
+++ b/aws/notifications.tf
@@ -24,6 +24,12 @@ resource "aws_sns_topic_subscription" "sms" {
   endpoint  = var.phone
 }
 
+# this is an account-wide setting - can be overridden when sending individual
+# messages
+resource "aws_sns_sms_preferences" "sms" {
+  default_sender_id = "BARRU-OPS"
+}
+
 ## terraform cannot create the email subscription because it must be
 ## manually confirmed
 # resource "aws_sns_topic_subscription" "email" {


### PR DESCRIPTION
This is now required to send messages to UK numbers.  Unfortunately, this is an account-wide setting, rather than a topic setting, but I only have the one topic so it's not so bad.