### PR TITLE
[dns] Reject emails which fail barrucadu.co.uk SPF

### DIFF
--- a/dns/zones/barrucadu.co.uk.yaml
+++ b/dns/zones/barrucadu.co.uk.yaml
@@ -15,7 +15,7 @@
   - type: "TXT"
     values:
       - "protonmail-verification=68e94ed315f5df9a3060beb99c6c8ca059e0c741"
-      - "v=spf1 include:_spf.protonmail.ch mx ~all"
+      - "v=spf1 include:_spf.protonmail.ch mx -all"
 
 "*":
   type: "CNAME"


### PR DESCRIPTION
The `~all` syntax means "if this fails, don't do anything" which isn't actually very useful.  The `-all` syntax means "if this fails, reject the email" which is much better.