### PR TITLE
[dns] Add empty _acme-challenge records to all zones

### DIFF
--- a/dns/zones/archhurd.org.yaml
+++ b/dns/zones/archhurd.org.yaml
@@ -19,6 +19,11 @@
   type: "TXT"
   value: "v=DKIM1\\; p="
 
+"_acme-challenge":
+  type: "TXT"
+  values:
+    - ""
+
 "_dmarc":
   type: "TXT"
   values:

--- a/dns/zones/barrucadu.co.uk.yaml
+++ b/dns/zones/barrucadu.co.uk.yaml
@@ -25,6 +25,11 @@
   type: "CNAME"
   value: "carcosa.barrucadu.co.uk."
 
+"_acme-challenge":
+  type: "TXT"
+  values:
+    - ""
+
 "_dmarc":
   type: "TXT"
   values:

--- a/dns/zones/barrucadu.com.yaml
+++ b/dns/zones/barrucadu.com.yaml
@@ -22,6 +22,11 @@
   type: "TXT"
   value: "v=DKIM1\\; p="
 
+"_acme-challenge":
+  type: "TXT"
+  values:
+    - ""
+
 "_dmarc":
   type: "TXT"
   values:

--- a/dns/zones/barrucadu.dev.yaml
+++ b/dns/zones/barrucadu.dev.yaml
@@ -22,6 +22,11 @@
   type: "TXT"
   value: "v=DKIM1\\; p="
 
+"_acme-challenge":
+  type: "TXT"
+  values:
+    - ""
+
 "_dmarc":
   type: "TXT"
   values:

--- a/dns/zones/barrucadu.uk.yaml
+++ b/dns/zones/barrucadu.uk.yaml
@@ -22,6 +22,11 @@
   type: "TXT"
   value: "v=DKIM1\\; p="
 
+"_acme-challenge":
+  type: "TXT"
+  values:
+    - ""
+
 "_dmarc":
   type: "TXT"
   values:

--- a/dns/zones/lainon.life.yaml
+++ b/dns/zones/lainon.life.yaml
@@ -22,6 +22,11 @@
   type: "TXT"
   value: "v=DKIM1\\; p="
 
+"_acme-challenge":
+  type: "TXT"
+  values:
+    - ""
+
 "_dmarc":
   type: "TXT"
   values:

--- a/dns/zones/lookwhattheshoggothdraggedin.com.yaml
+++ b/dns/zones/lookwhattheshoggothdraggedin.com.yaml
@@ -22,6 +22,11 @@
   type: "TXT"
   value: "v=DKIM1\\; p="
 
+"_acme-challenge":
+  type: "TXT"
+  values:
+    - ""
+
 "_dmarc":
   type: "TXT"
   values:

--- a/dns/zones/uzbl.org.yaml
+++ b/dns/zones/uzbl.org.yaml
@@ -22,6 +22,11 @@
   type: "TXT"
   value: "v=DKIM1\\; p="
 
+"_acme-challenge":
+  type: "TXT"
+  values:
+    - ""
+
 "_dmarc":
   type: "TXT"
   values:


### PR DESCRIPTION
The `* CNAME` records mess this up, so override them with a blank `TXT` record - which will also ensure left-over challenge records get cleaned up whenever I deploy DNS.