### PR TITLE
[dns] Disable geoDNS for some subdomains

### DIFF
--- a/dns/zones/barrucadu.co.uk.yaml
+++ b/dns/zones/barrucadu.co.uk.yaml
@@ -94,6 +94,14 @@
   type: "CNAME"
   value: "barrucadu.github.io."
 
+"foundry":
+  type: "CNAME"
+  value: "carcosa.barrucadu.co.uk."
+
+"misc":
+  type: "CNAME"
+  value: "carcosa.barrucadu.co.uk."
+
 "nixfiles.docs":
   type: "CNAME"
   value: "barrucadu.github.io."

--- a/dns/zones/barrucadu.dev.yaml
+++ b/dns/zones/barrucadu.dev.yaml
@@ -66,3 +66,11 @@
   type: "TXT"
   values:
     - "v=DMARC1\\; p=reject\\; sp=reject\\; adkim=s\\; aspf=s\\; fo=1\\; rua=mailto:mike+dmarc@barrucadu.co.uk"
+
+"cd":
+  type: "CNAME"
+  value: "carcosa.barrucadu.co.uk."
+
+"registry":
+  type: "CNAME"
+  value: "carcosa.barrucadu.co.uk."


### PR DESCRIPTION
These aren't mirrored, they all live on carcosa.